### PR TITLE
File extension changes 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.1.3
+* Change scaffolding initialization from `moda` to `morb`.
+* Change file extension to `mo.rb` so editors automagically do ruby syntax highlighting.
+* Change JSON file extension argument from `-f` (usually file or force) to `-e` for extension.
+* Docs location changed from https://docs.modabl.es to https://modabl.es/docs.
+
 #### 0.1.2
 * Replace `gen` scaffold with `moda`.
 * Add `--version` flag
@@ -11,4 +17,4 @@
 * Add `:dash` helper to convert underscore to dashes since ruby does not support dashes for method names.
 
 #### 0.1.0
-Initial release
+* Initial release

--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 DSL toolkit for Terraform and Packer.
 
-## Documentation
-https://docs.modabl.es
+## Docs
+https://modabl.es/docs

--- a/lib/modables_dsl/cli.rb
+++ b/lib/modables_dsl/cli.rb
@@ -8,8 +8,8 @@ module ModablesDSL
           self.opts['config'] = config
         end
 
-        args.on('-f', '--file-ext tf.json', 'JSON output file extension') do |file_ext|
-          self.opts['file-ext'] = file_ext
+        args.on('-e', '--ext-json tf.json', 'JSON file extension') do |ext_json|
+          self.opts['ext-json'] = ext_json
         end
 
         args.on('-v', '--version', 'DSL version') do |version|

--- a/lib/modables_dsl/config.rb
+++ b/lib/modables_dsl/config.rb
@@ -6,7 +6,7 @@ module ModablesDSL
 
         @config = {
           'dsl' => {
-            'ext_json'   => 'moda.json',
+            'ext_json'   => 'mo.json',
             'stack_dirs' => Array.new,
           }
         }

--- a/lib/modables_dsl/config.rb
+++ b/lib/modables_dsl/config.rb
@@ -6,7 +6,7 @@ module ModablesDSL
 
         @config = {
           'dsl' => {
-            'file_ext'   => 'moda.json',
+            'ext_json'   => 'moda.json',
             'stack_dirs' => Array.new,
           }
         }

--- a/lib/modables_dsl/dsl/core.rb
+++ b/lib/modables_dsl/dsl/core.rb
@@ -26,7 +26,7 @@ module ModablesDSL
       ActiveSupport::JSON.encode(@data)
     end
 
-    def self.moda
+    def self.morb
       yield
       self.encode_json
     end

--- a/lib/modables_dsl/generate.rb
+++ b/lib/modables_dsl/generate.rb
@@ -2,17 +2,17 @@ module ModablesDSL
   module Generate
 
     def self.files
-      self.stack_files.each do |moda_file|
+      self.stack_files.each do |morb_file|
 
-        file_prefix = moda_file.rpartition('.moda').first
+        file_prefix = morb_file.rpartition('.mo').first
         file_suffix = ModablesDSL::Cli.opts['ext-json'] || ModablesDSL::Config.get['dsl']['ext_json']
 
         destination_file = "#{file_prefix}.#{file_suffix}"
 
-        ModablesDSL::Message.log.info "Reading from #{moda_file}"
+        ModablesDSL::Message.log.info "Reading from #{morb_file}"
 
         File.open(destination_file, 'w') do |new_file|
-          new_file.write ModablesDSL::DSL.instance_eval IO.read moda_file
+          new_file.write ModablesDSL::DSL.instance_eval IO.read morb_file
         end
         
         ModablesDSL::Message.log.info "Wrote to #{destination_file}"
@@ -21,23 +21,23 @@ module ModablesDSL
 
     def self.stack_files
 
-      moda_files = Array.new
+      morb_files = Array.new
       stack_dirs = ModablesDSL::Config.get['dsl']['stack_dirs'] << Dir.pwd
 
       stack_dirs.each do |dir|
-        moda_files += Dir.glob("#{dir}/**/*.moda")
+        morb_files += Dir.glob("#{dir}/**/*.mo.rb")
       end
 
-      total_moda_files = moda_files.size
+      total_morb_files = morb_files.size
 
-      if total_moda_files == 0
-        ModablesDSL::Message.log.info '0 moda files found.'
+      if total_morb_files == 0
+        ModablesDSL::Message.log.info '0 morb files found.'
         exit 0
       else
-        ModablesDSL::Message.log.info "#{total_moda_files} moda #{"file".pluralize(total_moda_files)} found"
+        ModablesDSL::Message.log.info "#{total_morb_files} morb #{"file".pluralize(total_morb_files)} found"
       end
 
-      moda_files
+      morb_files
     end
 
   end

--- a/lib/modables_dsl/generate.rb
+++ b/lib/modables_dsl/generate.rb
@@ -5,7 +5,7 @@ module ModablesDSL
       self.stack_files.each do |moda_file|
 
         file_prefix = moda_file.rpartition('.moda').first
-        file_suffix = ModablesDSL::Cli.opts['file-ext'] || ModablesDSL::Config.get['dsl']['file_ext']
+        file_suffix = ModablesDSL::Cli.opts['ext-json'] || ModablesDSL::Config.get['dsl']['ext_json']
 
         destination_file = "#{file_prefix}.#{file_suffix}"
 

--- a/lib/modables_dsl/version.rb
+++ b/lib/modables_dsl/version.rb
@@ -1,3 +1,3 @@
 module ModablesDSL
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/test/dsl/test_basic.rb
+++ b/test/dsl/test_basic.rb
@@ -9,7 +9,7 @@ module TestModablesDSL
     def test_basic
 
       json_blob = ModablesDSL::DSL.instance_eval do
-        moda do
+        morb do
           provider :aws do
             region 'us-east-1'
           end

--- a/test/dsl/test_dash.rb
+++ b/test/dsl/test_dash.rb
@@ -9,7 +9,7 @@ module TestModablesDSL
     def test_dash
 
       json_blob = ModablesDSL::DSL.instance_eval do
-        moda do
+        morb do
 
           resource :google_compute_instance, :www_test do
             metadata do

--- a/test/dsl/test_json.rb
+++ b/test/dsl/test_json.rb
@@ -9,7 +9,7 @@ module TestModablesDSL
     def test_json
 
       json_blob = ModablesDSL::DSL.instance_eval do
-        moda do
+        morb do
 
           resource :aws_iam_role, :test do
             name 'test-role'

--- a/test/dsl/test_list.rb
+++ b/test/dsl/test_list.rb
@@ -9,7 +9,7 @@ module TestModablesDSL
     def test_list
 
       json_blob = ModablesDSL::DSL.instance_eval do
-        moda do
+        morb do
 
           resource :aws_security_group, :test do
             name 'test-sg'


### PR DESCRIPTION
Changes being released in 0.1.3.

* Change scaffolding initialization from `moda` to `morb`.
* Change file extension to `mo.rb` so editors automagically do ruby syntax highlighting.
* Change JSON file extension argument from `-f` (usually file or force) to `-e` for extension.
* Docs location changed from https://docs.modabl.es to https://modabl.es/docs.